### PR TITLE
Fixes for Ratpack usage.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,10 @@ repositories {
 
 dependencies {
   compile "io.projectreactor:reactor-stream:$reactorVersion"
-  compile "io.projectreactor:reactor-net:$reactorVersion"
+  compile "io.projectreactor:reactor-net:$reactorVersion", {
+    // Use Netty 4.1, dragged in by Ratpack
+    exclude group: "io.netty"
+  }
 
   compile "io.reactivex:rxjava:$rxJavaVersion"
   compile "io.reactivex:rxjava-reactive-streams:$rxJavaRSVersion"

--- a/src/main/java/org/reactivestreams/examples/Interop101.java
+++ b/src/main/java/org/reactivestreams/examples/Interop101.java
@@ -57,7 +57,6 @@ public class Interop101 {
 		// Reactor Stream starting with START on the subscriber thread, then emits Akka Source with some log
 		final Stream<String> linesStream = Streams
 				.wrap(stringPub)
-				.startWith("START")
 				.log("reactor.map")
 				.map(i -> i + "!");
 
@@ -67,7 +66,7 @@ public class Interop101 {
 						.handlers(chain -> chain
 										.get(":name", ctx ->
 														// and now render the HTTP response
-														ctx.render(ResponseChunks.stringChunks(linesStream))
+														ctx.render(ResponseChunks.stringChunks(ctx.stream(linesStream)))
 										)
 						)
 		);


### PR DESCRIPTION
When consuming an async stream, it has to be bound to the current execution. Among other things, this basically delivers the stream items on to the relevant event loop before the response is sent.
